### PR TITLE
Removed version from jar filename

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -19,6 +19,9 @@ VERSION=$(grep version pom.xml | head -1 | perl -pe 's/[^\d.]//g')
 PACKAGE_VERSION=$VERSION~krux$( date -u +%Y%m%d%H%M )
 PACKAGE_NAME=$NAME
 
+### Rename jar for packaging
+mv krux-tcp-stream-kafka-producer-$VERSION-full.jar krux-tcp-stream-kafka-producer-full.jar
+
 ### List of files to package
 FILES=krux-tcp-stream-kafka-producer-full.jar
 

--- a/package.sh
+++ b/package.sh
@@ -20,7 +20,7 @@ PACKAGE_VERSION=$VERSION~krux$( date -u +%Y%m%d%H%M )
 PACKAGE_NAME=$NAME
 
 ### List of files to package
-FILES=krux-tcp-stream-kafka-producer-$VERSION-full.jar
+FILES=krux-tcp-stream-kafka-producer-full.jar
 
 ### Where this package will be installed
 DEST_DIR="/usr/local/${NAME}/"

--- a/package.sh
+++ b/package.sh
@@ -20,7 +20,7 @@ PACKAGE_VERSION=$VERSION~krux$( date -u +%Y%m%d%H%M )
 PACKAGE_NAME=$NAME
 
 ### Rename jar for packaging
-mv krux-tcp-stream-kafka-producer-$VERSION-full.jar krux-tcp-stream-kafka-producer-full.jar
+mv "${TARGET}/krux-tcp-stream-kafka-producer-$VERSION-full.jar" "${TARGET}/krux-tcp-stream-kafka-producer-full.jar"
 
 ### List of files to package
 FILES=krux-tcp-stream-kafka-producer-full.jar


### PR DESCRIPTION
The debian package will determine version and we can remove the hard coded filename with version in the puppet manifest.